### PR TITLE
Add extra includes to get build running for core lib only

### DIFF
--- a/Pdf4QtLibCore/sources/pdfannotation.cpp
+++ b/Pdf4QtLibCore/sources/pdfannotation.cpp
@@ -26,6 +26,7 @@
 #include "pdfpainterutils.h"
 #include "pdfdocumentbuilder.h"
 
+#include <QtMath>
 #include <QIcon>
 
 #include "pdfdbgheap.h"

--- a/Pdf4QtLibCore/sources/pdffunction.cpp
+++ b/Pdf4QtLibCore/sources/pdffunction.cpp
@@ -23,6 +23,7 @@
 #include "pdfutils.h"
 
 #include <QIODevice>
+#include <QtMath>
 
 #include "pdfdbgheap.h"
 

--- a/Pdf4QtLibCore/sources/pdfglobal.h
+++ b/Pdf4QtLibCore/sources/pdfglobal.h
@@ -25,6 +25,7 @@
 #include <limits>
 #include <tuple>
 #include <array>
+#include <cmath>
 
 #include <pdf4qtlibcore_export.h>
 

--- a/Pdf4QtLibCore/sources/pdficontheme.cpp
+++ b/Pdf4QtLibCore/sources/pdficontheme.cpp
@@ -20,6 +20,7 @@
 #include <QDir>
 #include <QFile>
 #include <QCoreApplication>
+#include <QTextStream>
 
 #include "pdfdbgheap.h"
 

--- a/Pdf4QtLibCore/sources/pdfpagecontentprocessor.cpp
+++ b/Pdf4QtLibCore/sources/pdfpagecontentprocessor.cpp
@@ -24,6 +24,7 @@
 #include "pdfstreamfilters.h"
 
 #include <QPainterPathStroker>
+#include <QtMath>
 
 #include "pdfdbgheap.h"
 

--- a/Pdf4QtLibCore/sources/pdfpainter.cpp
+++ b/Pdf4QtLibCore/sources/pdfpainter.cpp
@@ -21,6 +21,7 @@
 
 #include <QPainter>
 #include <QCryptographicHash>
+#include <QtMath>
 
 #include "pdfdbgheap.h"
 

--- a/Pdf4QtLibCore/sources/pdfrenderer.cpp
+++ b/Pdf4QtLibCore/sources/pdfrenderer.cpp
@@ -24,6 +24,7 @@
 
 #include <QDir>
 #include <QElapsedTimer>
+#include <QtMath>
 
 #ifdef PDF4QT_ENABLE_OPENGL
 #include <QOpenGLContext>

--- a/Pdf4QtLibCore/sources/pdfsecurityhandler.cpp
+++ b/Pdf4QtLibCore/sources/pdfsecurityhandler.cpp
@@ -24,6 +24,8 @@
 #include "pdfcertificatemanager.h"
 
 #include <QRandomGenerator>
+#include <QtMath>
+#include <QtEndian>
 
 #include "pdfdbgheap.h"
 

--- a/Pdf4QtLibCore/sources/pdfstructuretree.h
+++ b/Pdf4QtLibCore/sources/pdfstructuretree.h
@@ -18,6 +18,8 @@
 #ifndef PDFSTRUCTURETREE_H
 #define PDFSTRUCTURETREE_H
 
+#include <QSharedPointer>
+
 #include "pdfobject.h"
 #include "pdfobjectutils.h"
 #include "pdffile.h"

--- a/Pdf4QtLibCore/sources/pdftextlayout.cpp
+++ b/Pdf4QtLibCore/sources/pdftextlayout.cpp
@@ -19,6 +19,7 @@
 #include "pdfutils.h"
 #include "pdfexecutionpolicy.h"
 
+#include <QtMath>
 #include <QMutex>
 #include <QPainter>
 #include <QIODevice>

--- a/Pdf4QtLibCore/sources/pdftransparencyrenderer.cpp
+++ b/Pdf4QtLibCore/sources/pdftransparencyrenderer.cpp
@@ -23,6 +23,7 @@
 #include "pdfpattern.h"
 #include "pdfdbgheap.h"
 
+#include <QtMath>
 #include <iterator>
 
 namespace pdf

--- a/Pdf4QtLibCore/sources/pdfutils.cpp
+++ b/Pdf4QtLibCore/sources/pdfutils.cpp
@@ -19,7 +19,7 @@
 #include "pdfexception.h"
 
 #include <QtGlobal>
-
+#include <QtMath>
 #include "pdfdbgheap.h"
 
 #include <jpeglib.h>

--- a/Pdf4QtLibCore/sources/pdfxfaengine.cpp
+++ b/Pdf4QtLibCore/sources/pdfxfaengine.cpp
@@ -30,6 +30,7 @@
 #include <QTextBlock>
 #include <QFontDatabase>
 #include <QAbstractTextDocumentLayout>
+#include <QtMath>
 
 #include "pdfdbgheap.h"
 

--- a/Pdf4QtLibCore/sources/pdfxreftable.cpp
+++ b/Pdf4QtLibCore/sources/pdfxreftable.cpp
@@ -22,6 +22,7 @@
 #include "pdfstreamfilters.h"
 
 #include <QIODevice>
+#include <QDataStream>
 
 #include "pdfdbgheap.h"
 


### PR DESCRIPTION
I had to add a handful of includes to get the core library building after 9f624e5569bac8214e9c4fec763c4d08e0008603 -- not sure why this is different on my system, it may be dependent on the exact Qt version...