### PR TITLE
fix(pdfccittfaxdecoder): Remove whitespace in _bitlength operator

### DIFF
--- a/Pdf4QtLibCore/sources/pdfccittfaxdecoder.cpp
+++ b/Pdf4QtLibCore/sources/pdfccittfaxdecoder.cpp
@@ -24,7 +24,7 @@ namespace pdf
 {
 
 template<char... Digits>
-constexpr uint8_t operator "" _bitlength()
+constexpr uint8_t operator ""_bitlength()
 {
     return sizeof...(Digits);
 }


### PR DESCRIPTION
This fixes a compilation warning with newer clang version. Indeed, the whitespace between "" and _bitlength is no longer allowed. This was permitted in older versions of the standard but has since been deprecated.

```
error: identifier '_bitlength' preceded by whitespace in a literal
operator declaration is deprecated
[-Werror,-Wdeprecated-literal-operator]
     27 | constexpr uint8_t operator "" _bitlength()
        |                   ~~~~~~~~~~~~^~~~~~~~~~
        |                   operator""_bitlength
```