### PR TITLE
fix(Pdf4QtLibCore): add set_source_files_properties 

### DIFF
--- a/Pdf4QtLibCore/CMakeLists.txt
+++ b/Pdf4QtLibCore/CMakeLists.txt
@@ -157,6 +157,9 @@ add_library(Pdf4QtLibCore SHARED
 
 include(GenerateExportHeader)
 
+# Workaround to suppress CLANG error on unused private field
+set_source_files_properties(sources/pdfdocumentwriter.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-private-field")
+
 GENERATE_EXPORT_HEADER(Pdf4QtLibCore
                        EXPORT_MACRO_NAME
                        PDF4QTLIBCORESHARED_EXPORT


### PR DESCRIPTION
to avoid error/warning on pdfdocumentwriter as m_progress is unused