### PR TITLE
Pdf4QtLibCore: add explicite call to std::atomic::load() function to ensure c++15 compatibility

### DIFF
--- a/Pdf4QtLibCore/sources/pdfdocumentsanitizer.cpp
+++ b/Pdf4QtLibCore/sources/pdfdocumentsanitizer.cpp
@@ -161,7 +161,7 @@ void PDFDocumentSanitizer::performSanitizeMetadata()
 
     PDFExecutionPolicy::execute(PDFExecutionPolicy::Scope::Unknown, objects.begin(), objects.end(), processEntry);
     m_storage.setObjects(qMove(objects));
-    Q_EMIT sanitizationProgress(tr("Metadata streams removed: %1").arg(counter));
+    Q_EMIT sanitizationProgress(tr("Metadata streams removed: %1").arg(counter.load()));
 }
 
 void PDFDocumentSanitizer::performSanitizeOutline()

--- a/Pdf4QtLibCore/sources/pdfoptimizer.cpp
+++ b/Pdf4QtLibCore/sources/pdfoptimizer.cpp
@@ -194,7 +194,7 @@ bool PDFOptimizer::performDereferenceSimpleObjects()
 
     PDFExecutionPolicy::execute(PDFExecutionPolicy::Scope::Unknown, objects.begin(), objects.end(), processEntry);
     m_storage.setObjects(qMove(objects));
-    Q_EMIT optimizationProgress(tr("Simple objects dereferenced and embedded: %1").arg(counter));
+    Q_EMIT optimizationProgress(tr("Simple objects dereferenced and embedded: %1").arg(counter.load()));
 
     return false;
 }
@@ -213,7 +213,7 @@ bool PDFOptimizer::performRemoveNullObjects()
 
     PDFExecutionPolicy::execute(PDFExecutionPolicy::Scope::Unknown, objects.begin(), objects.end(), processEntry);
     m_storage.setObjects(qMove(objects));
-    Q_EMIT optimizationProgress(tr("Null objects entries from dictionaries removed: %1").arg(counter));
+    Q_EMIT optimizationProgress(tr("Null objects entries from dictionaries removed: %1").arg(counter.load()));
 
     return false;
 }
@@ -238,7 +238,7 @@ bool PDFOptimizer::performRemoveUnusedObjects()
 
     PDFExecutionPolicy::execute(PDFExecutionPolicy::Scope::Unknown, range.begin(), range.end(), processEntry);
     m_storage.setObjects(qMove(objects));
-    Q_EMIT optimizationProgress(tr("Unused objects removed: %1").arg(counter));
+    Q_EMIT optimizationProgress(tr("Unused objects removed: %1").arg(counter.load()));
 
     return counter > 0;
 }
@@ -311,7 +311,7 @@ bool PDFOptimizer::performMergeIdenticalObjects()
     }
 
     m_storage.setObjects(qMove(objects));
-    Q_EMIT optimizationProgress(tr("Identical objects merged: %1").arg(counter));
+    Q_EMIT optimizationProgress(tr("Identical objects merged: %1").arg(counter.load()));
 
     return counter > 0;
 }
@@ -457,7 +457,7 @@ bool PDFOptimizer::performRecompressFlateStreams()
 
     PDFExecutionPolicy::execute(PDFExecutionPolicy::Scope::Unknown, objects.begin(), objects.end(), processEntry);
     m_storage.setObjects(qMove(objects));
-    Q_EMIT optimizationProgress(tr("Bytes saved by recompressing stream: %1").arg(bytesSaved));
+    Q_EMIT optimizationProgress(tr("Bytes saved by recompressing stream: %1").arg(bytesSaved.load()));
 
     return false;
 }


### PR DESCRIPTION
This fix the use of the deleted copy constructor of std::atomic (since c++15).