### PR TITLE
Fix overloaded-virtual warnings

### DIFF
--- a/Pdf4QtLibCore/sources/pdfxfaengine.cpp
+++ b/Pdf4QtLibCore/sources/pdfxfaengine.cpp
@@ -9868,6 +9868,8 @@ class PDFXFALayoutEngine : public xfa::XFA_AbstractVisitor
 {
     // XFA_AbstractVisitor interface
 public:
+    using xfa::XFA_AbstractVisitor::visit;
+
     virtual void visit(const xfa::XFA_template* node) override;
     virtual void visit(const xfa::XFA_pageArea* node) override;
     virtual void visit(const xfa::XFA_pageSet* node) override;


### PR DESCRIPTION
Fixes "virtual void pdf::xfa::XFA_AbstractVisitor::visit(...)’ was hidden [-Woverloaded-virtual=]" warnings when building with gcc