### PR TITLE
Fix checkbox functionality and add Save to Pdf4QtViewer

### DIFF
--- a/Pdf4QtLibCore/sources/pdfannotation.cpp
+++ b/Pdf4QtLibCore/sources/pdfannotation.cpp
@@ -3263,6 +3263,7 @@ void PDFWidgetAnnotation::draw(AnnotationDrawParameters& parameters) const
 
     PDFPainterStateGuard guard(parameters.painter);
     parameters.painter->setCompositionMode(getCompositionMode());
+    parameters.boundingRectangle = getRectangle();
 
     if (parameters.formManager->isEditorDrawEnabled(formField))
     {
@@ -3402,15 +3403,26 @@ void PDFWidgetAnnotation::draw(AnnotationDrawParameters& parameters) const
                         painter->setBrush(Qt::NoBrush);
                         painter->drawRect(rectangle);
 
-                        if (parameters.key.second != "Off")
+                        if (!parameters.key.second.isEmpty() && parameters.key.second != "Off")
                         {
-                            QRectF rectangleMark = rectangle;
-                            rectangleMark.setWidth(rectangle.width() * 0.75);
-                            rectangleMark.setHeight(rectangle.height() * 0.75);
-                            rectangleMark.moveCenter(rectangle.center());
+                            const qreal size = qMin(rectangle.width(), rectangle.height());
+                            const qreal inset = qMin(qMax(size * 0.18, qreal(1.0)), size * 0.35);
+                            const QRectF rectangleMark = rectangle.adjusted(inset, inset, -inset, -inset);
 
-                            painter->drawLine(rectangleMark.topLeft(), rectangleMark.bottomRight());
-                            painter->drawLine(rectangleMark.bottomLeft(), rectangleMark.topRight());
+                            QPen markPen(Qt::black);
+                            markPen.setWidthF(qMax(size * 0.08, qreal(1.0)));
+                            markPen.setCapStyle(Qt::RoundCap);
+                            markPen.setJoinStyle(Qt::RoundJoin);
+                            painter->setPen(markPen);
+                            painter->setBrush(Qt::NoBrush);
+
+                            const qreal bottom = rectangleMark.top();
+                            const qreal top = rectangleMark.bottom();
+                            QPainterPath checkmarkPath;
+                            checkmarkPath.moveTo(rectangleMark.left(), bottom + rectangleMark.height() * 0.45);
+                            checkmarkPath.lineTo(rectangleMark.left() + rectangleMark.width() * 0.35, bottom);
+                            checkmarkPath.lineTo(rectangleMark.right(), top);
+                            painter->drawPath(checkmarkPath);
                         }
                         break;
                     }
@@ -3477,10 +3489,42 @@ std::vector<pdf::PDFAppeareanceStreams::Key> PDFWidgetAnnotation::getDrawKeys(co
                 case PDFFormFieldButton::ButtonType::CheckBox:
                 {
                     result = getAppearanceStreams().getAppearanceKeys();
-                    PDFAppeareanceStreams::Key offKey{ PDFAppeareanceStreams::Appearance::Normal, QByteArray() };
-                    if (std::find(result.cbegin(), result.cend(), offKey) == result.cend())
+
+                    for (PDFAppeareanceStreams::Key& key : result)
                     {
-                        result.push_back(qMove(offKey));
+                        if (key.first == PDFAppeareanceStreams::Appearance::Normal && key.second.isEmpty())
+                        {
+                            key.second = "Off";
+                        }
+                    }
+
+                    auto addKey = [&result](PDFAppeareanceStreams::Key key)
+                    {
+                        if (std::find(result.cbegin(), result.cend(), key) == result.cend())
+                        {
+                            result.push_back(qMove(key));
+                        }
+                    };
+
+                    addKey(PDFAppeareanceStreams::Key{ PDFAppeareanceStreams::Appearance::Normal, "Off" });
+
+                    for (const PDFFormWidget& formWidget : button->getWidgets())
+                    {
+                        if (formWidget.getWidget() == getSelfReference())
+                        {
+                            QByteArray onState = PDFFormFieldButton::getOnAppearanceState(formManager, &formWidget);
+                            if (!onState.isEmpty())
+                            {
+                                addKey(PDFAppeareanceStreams::Key{ PDFAppeareanceStreams::Appearance::Normal, qMove(onState) });
+                            }
+                            break;
+                        }
+                    }
+
+                    const QByteArray& appearanceState = getAppearanceState();
+                    if (!appearanceState.isEmpty() && appearanceState != "Off")
+                    {
+                        addKey(PDFAppeareanceStreams::Key{ PDFAppeareanceStreams::Appearance::Normal, appearanceState });
                     }
                     break;
                 }

--- a/Pdf4QtLibCore/sources/pdfform.cpp
+++ b/Pdf4QtLibCore/sources/pdfform.cpp
@@ -514,6 +514,12 @@ QByteArray PDFFormFieldButton::getOnAppearanceState(const PDFFormManager* formMa
         }
     }
 
+    const PDFFormFieldButton* button = dynamic_cast<const PDFFormFieldButton*>(widget->getParent());
+    if (button && button->getButtonType() == PDFFormFieldButton::ButtonType::CheckBox)
+    {
+        return "Yes";
+    }
+
     return QByteArray();
 }
 
@@ -550,6 +556,7 @@ bool PDFFormFieldButton::setValue(const SetValueParameters& parameters)
     QByteArray state = parameters.value.getString();
     parameters.modifier->markFormFieldChanged();
     builder->setFormFieldValue(getSelfReference(), parameters.value);
+    m_value = parameters.value;
 
     // Change widget appearance states
     const bool isRadio = getFlags().testFlag(Radio);
@@ -577,6 +584,7 @@ bool PDFFormFieldButton::setValue(const SetValueParameters& parameters)
             QByteArray offState = PDFFormFieldButton::getOffAppearanceState(parameters.formManager, &formWidget);
             builder->setAnnotationAppearanceState(formWidget.getWidget(), offState);
         }
+        builder->updateAnnotationAppearanceStreams(formWidget.getWidget());
         parameters.modifier->markAnnotationsChanged();
     }
 

--- a/Pdf4QtLibCore/sources/pdfform.h
+++ b/Pdf4QtLibCore/sources/pdfform.h
@@ -303,8 +303,9 @@ public:
     const QStringList& getOptions() const { return m_options; }
 
     /// Returns appearance state, which corresponds to the checked
-    /// state of checkbox or radio button. If error occurs, then
-    /// empty byte array is returned.
+    /// state of checkbox or radio button. For checkboxes without
+    /// an explicit on-state, returns the common 'Yes' state. If no
+    /// state can be resolved, then empty byte array is returned.
     /// \param formManager Form manager
     /// \param widget Widget
     static QByteArray getOnAppearanceState(const PDFFormManager* formManager, const PDFFormWidget* widget);

--- a/Pdf4QtLibGui/pdfprogramcontroller.cpp
+++ b/Pdf4QtLibGui/pdfprogramcontroller.cpp
@@ -1222,6 +1222,7 @@ void PDFProgramController::saveDocument(const QString& fileName)
     {
         m_formManager->setFocusToEditor(nullptr);
     }
+    prepareFormFieldAppearancesForSave();
 
     pdf::PDFDocumentWriter writer(nullptr);
     pdf::PDFOperationResult result = writer.write(fileName, m_pdfDocument.data(), true);
@@ -1246,6 +1247,72 @@ void PDFProgramController::saveDocument(const QString& fileName)
     }
 
     updateFileWatcher();
+}
+
+void PDFProgramController::prepareFormFieldAppearancesForSave()
+{
+    if (!m_pdfDocument || !m_formManager || !m_formManager->hasAcroForm())
+    {
+        return;
+    }
+
+    pdf::PDFDocumentModifier modifier(m_pdfDocument.data());
+    pdf::PDFDocumentBuilder* builder = modifier.getBuilder();
+    builder->setFormManager(m_formManager);
+
+    const pdf::PDFObject& acroFormObject = m_pdfDocument->getCatalog()->getFormObject();
+    if (acroFormObject.isReference())
+    {
+        pdf::PDFObjectFactory objectBuilder;
+        objectBuilder.beginDictionary();
+        objectBuilder.beginDictionaryItem("NeedAppearances");
+        objectBuilder << true;
+        objectBuilder.endDictionaryItem();
+        objectBuilder.endDictionary();
+
+        builder->mergeTo(acroFormObject.getReference(), objectBuilder.takeObject());
+        modifier.markFormFieldChanged();
+    }
+
+    bool appearanceUpdated = false;
+    const pdf::PDFFormWidgets widgets = m_formManager->getWidgets();
+    for (const pdf::PDFFormWidget& widget : widgets)
+    {
+        const pdf::PDFFormField* formField = m_formManager->getFormFieldForWidget(widget.getWidget());
+        if (!formField)
+        {
+            continue;
+        }
+
+        switch (formField->getFieldType())
+        {
+            case pdf::PDFFormField::FieldType::Button:
+            case pdf::PDFFormField::FieldType::Text:
+            case pdf::PDFFormField::FieldType::Choice:
+                builder->updateAnnotationAppearanceStreams(widget.getWidget());
+                appearanceUpdated = true;
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    if (appearanceUpdated)
+    {
+        modifier.markAnnotationsChanged();
+    }
+
+    if (modifier.finalize())
+    {
+        pdf::PDFModifiedDocument document(modifier.getDocument(), m_optionalContentActivity, modifier.getFlags());
+        pdf::PDFDocumentPointer oldDocument = std::move(m_pdfDocument);
+        Q_UNUSED(oldDocument);
+
+        m_pdfDocument = document;
+        document.setOptionalContentActivity(m_optionalContentActivity);
+        setDocument(document, {}, false);
+    }
 }
 
 void PDFProgramController::savePageLayoutPerDocument()

--- a/Pdf4QtLibGui/pdfprogramcontroller.cpp
+++ b/Pdf4QtLibGui/pdfprogramcontroller.cpp
@@ -1218,6 +1218,11 @@ void PDFProgramController::saveDocument(const QString& fileName)
 {
     updateFileWatcher(true);
 
+    if (m_formManager)
+    {
+        m_formManager->setFocusToEditor(nullptr);
+    }
+
     pdf::PDFDocumentWriter writer(nullptr);
     pdf::PDFOperationResult result = writer.write(fileName, m_pdfDocument.data(), true);
     if (result)

--- a/Pdf4QtLibGui/pdfprogramcontroller.h
+++ b/Pdf4QtLibGui/pdfprogramcontroller.h
@@ -437,6 +437,7 @@ private:
     void readSettings(Settings settings);
 
     void saveDocument(const QString& fileName);
+    void prepareFormFieldAppearancesForSave();
     void savePageLayoutPerDocument();
 
     PDFActionManager* m_actionManager;

--- a/Pdf4QtLibGui/pdfviewermainwindow.cpp
+++ b/Pdf4QtLibGui/pdfviewermainwindow.cpp
@@ -119,6 +119,8 @@ PDFViewerMainWindow::PDFViewerMainWindow(QWidget* parent) :
     m_actionManager->setAction(PDFActionManager::Open, ui->actionOpen);
     m_actionManager->setAction(PDFActionManager::Close, ui->actionClose);
     m_actionManager->setAction(PDFActionManager::AutomaticDocumentRefresh, ui->actionAutomaticDocumentRefresh);
+    m_actionManager->setAction(PDFActionManager::Save, ui->actionSave);
+    m_actionManager->setAction(PDFActionManager::SaveAs, ui->actionSave_As);
     m_actionManager->setAction(PDFActionManager::Quit, ui->actionQuit);
     m_actionManager->setAction(PDFActionManager::ZoomIn, ui->actionZoom_In);
     m_actionManager->setAction(PDFActionManager::ZoomOut, ui->actionZoom_Out);
@@ -230,7 +232,7 @@ PDFViewerMainWindow::PDFViewerMainWindow(QWidget* parent) :
     ui->mainToolBar->addSeparator();
 
     // Special tools
-    m_programController->initialize(PDFProgramController::Features(PDFProgramController::TextToSpeech | PDFProgramController::Tools), this, this, m_actionManager, m_progress);
+    m_programController->initialize(PDFProgramController::Features(PDFProgramController::TextToSpeech | PDFProgramController::Tools | PDFProgramController::Forms), this, this, m_actionManager, m_progress);
     setCentralWidget(m_programController->getPdfWidget());
     setFocusProxy(m_programController->getPdfWidget());
 

--- a/Pdf4QtLibGui/pdfviewermainwindow.ui
+++ b/Pdf4QtLibGui/pdfviewermainwindow.ui
@@ -31,6 +31,9 @@
     <addaction name="actionClose"/>
     <addaction name="actionAutomaticDocumentRefresh"/>
     <addaction name="separator"/>
+    <addaction name="actionSave"/>
+    <addaction name="actionSave_As"/>
+    <addaction name="separator"/>
     <addaction name="actionSend_by_E_Mail"/>
     <addaction name="actionPrint"/>
     <addaction name="separator"/>
@@ -162,6 +165,8 @@
     <bool>false</bool>
    </attribute>
    <addaction name="actionOpen"/>
+   <addaction name="actionSave"/>
+   <addaction name="actionSave_As"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionOpen">
@@ -180,6 +185,24 @@
    </property>
    <property name="text">
     <string>&amp;Close</string>
+   </property>
+  </action>
+  <action name="actionSave">
+   <property name="icon">
+    <iconset resource="pdf4qtlibgui.qrc">
+     <normaloff>:/resources/save.svg</normaloff>:/resources/save.svg</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Save</string>
+   </property>
+  </action>
+  <action name="actionSave_As">
+   <property name="icon">
+    <iconset resource="pdf4qtlibgui.qrc">
+     <normaloff>:/resources/save-as.svg</normaloff>:/resources/save-as.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Save &amp;As...</string>
    </property>
   </action>
   <action name="actionQuit">


### PR DESCRIPTION
## Summary
This PR is meant to improve basic PDF form support in Pdf4QtViewer, especially checkboxes and saving filled forms.

I noticed that text fields could be edited, but checkbox fields were not showing a proper checkmark when clicked. This changes the checkbox drawing so checked boxes use a checkmark, and also handles PDFs where the checkbox does not already have a clear on-state by using `/Yes` as a fallback.

I also added Save and Save As to Pdf4QtViewer so filled forms can be saved from the viewer. After more testing, I also added a save-time refresh for form appearances so text entered into fields stays visible after the saved PDF is opened in other programs like Adobe Acrobat.

## Changes
- Draw checked checkboxes with a checkmark instead of an X (which did not appear).
- Add a fallback `/Yes` checked state for checkbox fields.
- Update checkbox appearance streams after clicking them.
- Enable form field support in Pdf4QtViewer.
- Add Save and Save As actions to Pdf4QtViewer.
- Make sure the active form edit is committed before saving.
- Refresh form field appearances before saving so typed text is visible after reopening the saved PDF in other PDF programs.

## Notes
I did not add any new libraries or dependencies.

## Testing
- Built the Windows release locally.
- Opened and loaded a PDF, edited text fields and checkboxes in Pdf4QtViewer, and saved it.
- Reopened the saved PDF in Adobe Acrobat and confirmed the saved text and checkbox appearances were visible.